### PR TITLE
Add timeout in order to prevent CircleCI from failing

### DIFF
--- a/spec/support/wait_for_ajax.rb
+++ b/spec/support/wait_for_ajax.rb
@@ -3,8 +3,9 @@
 
 module WaitForAjax
   def wait_for_ajax
+    endtime = Time.now + 15.seconds
     Timeout.timeout(Capybara.default_wait_time) do
-      loop until finished_all_ajax_requests?
+      loop until finished_all_ajax_requests? or Time.now > endtime
     end
     # PhantomJS is much faster, a way too fast...
     if ENV['PHANTOM_JS'] == 'true'


### PR DESCRIPTION
Add timeout in order to prevent CircleCI from failing when wait_for_ajax didn't work correctly
