### PR TITLE
#335 change height of provider logo on course detail page

### DIFF
--- a/app/assets/stylesheets/partials/_courses.scss
+++ b/app/assets/stylesheets/partials/_courses.scss
@@ -43,12 +43,11 @@ $course-img-height: 250px;
 
     .options {
       position: absolute;
-      bottom: 0px;
-      right: 10px;
+      bottom: 20px;
+      right: 20px;
 
       img {
-        height: 90px;
-        padding: 20px;
+        height: 40px;
       }
     }
   }


### PR DESCRIPTION
Change height of provider logo on course detail page from 40px to 90px so it is shown. Solves: #335 

Branch can be deleted after merge.
