### PR TITLE
Add integration repo tokens for forked repos

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,8 @@ machine:
     GEMNASIUM_TESTSUITE: "bundle check"
     GEMNASIUM_PROJECT_SLUG: "mammooc/mammooc.org"
     COVERALLS_PARALLEL: "true"
+    COVERALLS_REPO_TOKEN: "ZgW6tvGP2hrQInuZLErCADQ95Hj8AvOkK"
+    PULLREVIEW_REPO_TOKEN: "528fdb57300dc3262f4e37424a36b2bf"
   services:
     - docker
 


### PR DESCRIPTION
Other GitHub users need the integrated keys in order to have coveralls.io and pullreview.com status checks for PR.