### PR TITLE
Remove old PullReview Parts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -118,7 +118,6 @@ group :development, :test do
   gem 'simplecov', require: false
   gem 'rubocop', require: false
   gem 'rubocop-rspec', require: false
-  gem 'pullreview-coverage', require: false
   gem 'coveralls', require: false
 
   gem 'quiet_assets'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,7 +76,6 @@ GEM
     capybara-selenium (0.0.6)
       capybara
       selenium-webdriver
-    certifi (2015.11.20)
     childprocess (0.5.8)
       ffi (~> 1.0, >= 1.0.11)
     chronic (0.10.2)
@@ -232,9 +231,6 @@ GEM
       activerecord (>= 3.0)
       i18n (>= 0.5.0)
       railties (>= 3.0.0)
-    pullreview-coverage (0.0.5)
-      certifi
-      simplecov (>= 0.7.1, < 1.0.0)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
     rack (1.6.4)
@@ -427,7 +423,6 @@ DEPENDENCIES
   pg
   poltergeist
   public_activity
-  pullreview-coverage
   quiet_assets
   rails (= 4.2.5)
   rails-i18n

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,12 +3,10 @@ require 'simplecov'
 
 if ENV['CIRCLE_ARTIFACTS'] && ENV['GEMNASIUM'] != 'true'
   require 'coveralls'
-  require 'pullreview/coverage'
 
   formatters = []
   formatters << SimpleCov::Formatter::HTMLFormatter
   formatters << Coveralls::SimpleCov::Formatter
-  formatters << PullReview::Coverage::Formatter
   SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[*formatters]
 
   dir = File.join('..', '..', '..', ENV['CIRCLE_ARTIFACTS'], 'coverage')


### PR DESCRIPTION
This commit will remove the following deprecation warning:

/home/ubuntu/mammooc.org/spec/spec_helper.rb:12:in `<top (required)>': [DEPRECATION] ::[] is deprecated. Use ::new instead.

The deprecation was injected due to the usage of `PullReview::Coverage::Formatter` which is no longer needed because we removed PullReview.com in an earlier commit.