### PR TITLE
Exclude db path from code climate code analysis

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -47,3 +47,4 @@ ratings:
 exclude_paths:
   - spec/**
   - vendor/**
+  - db/**


### PR DESCRIPTION
Currently, our code climate rating was decreased to 3.9 (instead of 4.0 - the top value) due to the auto generated db/schema.rb file. This PR excludes the whole db path, so that this won't happen again.