### PR TITLE
Fix rubocop offenses

### DIFF
--- a/app/controllers/concerns/abstract_xikolo_connector.rb
+++ b/app/controllers/concerns/abstract_xikolo_connector.rb
@@ -2,10 +2,10 @@
 # frozen_string_literal: true
 
 class AbstractXikoloConnector < AbstractMoocProviderConnector
-  AUTHENTICATE_API = 'authenticate/'.freeze
-  ENROLLMENTS_API = 'users/me/enrollments/'.freeze
-  DATES_API = 'dates/'.freeze
-  COURSES_API = 'courses/'.freeze
+  AUTHENTICATE_API = 'authenticate/'
+  ENROLLMENTS_API = 'users/me/enrollments/'
+  DATES_API = 'dates/'
+  COURSES_API = 'courses/'
 
   private
 

--- a/app/controllers/concerns/cnmooc_house_connector.rb
+++ b/app/controllers/concerns/cnmooc_house_connector.rb
@@ -2,8 +2,8 @@
 # frozen_string_literal: true
 
 class CnmoocHouseConnector < AbstractXikoloConnector
-  NAME = 'cnmooc.house'.freeze
-  ROOT_API = 'https://cnmooc.house/api/'.freeze
-  ROOT_API_V2 = 'https://cnmooc.house/api/v2/'.freeze
-  COURSE_LINK = 'https://cnmooc.house/courses/'.freeze
+  NAME = 'cnmooc.house'
+  ROOT_API = 'https://cnmooc.house/api/'
+  ROOT_API_V2 = 'https://cnmooc.house/api/v2/'
+  COURSE_LINK = 'https://cnmooc.house/courses/'
 end

--- a/app/controllers/concerns/coursera_connector.rb
+++ b/app/controllers/concerns/coursera_connector.rb
@@ -2,19 +2,19 @@
 # frozen_string_literal: true
 
 class CourseraConnector < AbstractMoocProviderConnector
-  NAME = 'coursera'.freeze
-  COURSE_LINK = 'https://www.coursera.org/course/'.freeze
+  NAME = 'coursera'
+  COURSE_LINK = 'https://www.coursera.org/course/'
 
-  OAUTH_API = 'https://accounts.coursera.org/oauth2/v1/'.freeze
-  AUTHENTICATE_API = 'auth'.freeze
-  TOKEN_API = 'token'.freeze
+  OAUTH_API = 'https://accounts.coursera.org/oauth2/v1/'
+  AUTHENTICATE_API = 'auth'
+  TOKEN_API = 'token'
   OAUTH_CLIENT_ID = ENV['COURSERA_CLIENT_ID']
   OAUTH_SECRET_KEY = ENV['COURSERA_SECRET_KEY']
-  REDIRECT_URI = "#{Settings.root_url}/oauth/callback".freeze
+  REDIRECT_URI = "#{Settings.root_url}/oauth/callback"
 
-  ROOT_API = 'https://api.coursera.org/api/'.freeze
-  ENROLLMENTS_API = 'users/v1/me/enrollments'.freeze
-  COURSES_API = 'catalog.v1/courses'.freeze
+  ROOT_API = 'https://api.coursera.org/api/'
+  ENROLLMENTS_API = 'users/v1/me/enrollments'
+  COURSES_API = 'catalog.v1/courses'
 
   def oauth_link(destination, csrf_token)
     response_type = 'code'

--- a/app/controllers/concerns/mooc_house_connector.rb
+++ b/app/controllers/concerns/mooc_house_connector.rb
@@ -2,8 +2,8 @@
 # frozen_string_literal: true
 
 class MoocHouseConnector < AbstractXikoloConnector
-  NAME = 'mooc.house'.freeze
-  ROOT_API = 'https://mooc.house/api/'.freeze
-  ROOT_API_V2 = 'https://mooc.house/api/v2/'.freeze
-  COURSE_LINK = 'https://mooc.house/courses/'.freeze
+  NAME = 'mooc.house'
+  ROOT_API = 'https://mooc.house/api/'
+  ROOT_API_V2 = 'https://mooc.house/api/v2/'
+  COURSE_LINK = 'https://mooc.house/courses/'
 end

--- a/app/controllers/concerns/open_hpi_china_connector.rb
+++ b/app/controllers/concerns/open_hpi_china_connector.rb
@@ -2,8 +2,8 @@
 # frozen_string_literal: true
 
 class OpenHPIChinaConnector < AbstractXikoloConnector
-  NAME = 'openHPI China'.freeze
-  ROOT_API = 'https://openhpi.cn/api/'.freeze
-  ROOT_API_V2 = 'https://openhpi.cn/api/v2/'.freeze
-  COURSE_LINK = 'https://openhpi.cn/courses/'.freeze
+  NAME = 'openHPI China'
+  ROOT_API = 'https://openhpi.cn/api/'
+  ROOT_API_V2 = 'https://openhpi.cn/api/v2/'
+  COURSE_LINK = 'https://openhpi.cn/courses/'
 end

--- a/app/controllers/concerns/open_hpi_connector.rb
+++ b/app/controllers/concerns/open_hpi_connector.rb
@@ -2,8 +2,8 @@
 # frozen_string_literal: true
 
 class OpenHPIConnector < AbstractXikoloConnector
-  NAME = 'openHPI'.freeze
-  ROOT_API = 'https://open.hpi.de/api/'.freeze
-  ROOT_API_V2 = 'https://open.hpi.de/api/v2/'.freeze
-  COURSE_LINK = 'https://open.hpi.de/courses/'.freeze
+  NAME = 'openHPI'
+  ROOT_API = 'https://open.hpi.de/api/'
+  ROOT_API_V2 = 'https://open.hpi.de/api/v2/'
+  COURSE_LINK = 'https://open.hpi.de/courses/'
 end

--- a/app/controllers/concerns/open_sap_china_connector.rb
+++ b/app/controllers/concerns/open_sap_china_connector.rb
@@ -2,8 +2,8 @@
 # frozen_string_literal: true
 
 class OpenSAPChinaConnector < AbstractXikoloConnector
-  NAME = 'openSAP China'.freeze
-  ROOT_API = 'https://open.sap.cn/api/'.freeze
-  ROOT_API_V2 = 'https://open.sap.com/api/v2/'.freeze
-  COURSE_LINK = 'https://open.sap.cn/courses/'.freeze
+  NAME = 'openSAP China'
+  ROOT_API = 'https://open.sap.cn/api/'
+  ROOT_API_V2 = 'https://open.sap.com/api/v2/'
+  COURSE_LINK = 'https://open.sap.cn/courses/'
 end

--- a/app/controllers/concerns/open_sap_connector.rb
+++ b/app/controllers/concerns/open_sap_connector.rb
@@ -2,8 +2,8 @@
 # frozen_string_literal: true
 
 class OpenSAPConnector < AbstractXikoloConnector
-  NAME = 'openSAP'.freeze
-  ROOT_API = 'https://open.sap.com/api/'.freeze
-  ROOT_API_V2 = 'https://open.sap.com/api/v2/'.freeze
-  COURSE_LINK = 'https://open.sap.com/courses/'.freeze
+  NAME = 'openSAP'
+  ROOT_API = 'https://open.sap.com/api/'
+  ROOT_API_V2 = 'https://open.sap.com/api/v2/'
+  COURSE_LINK = 'https://open.sap.com/courses/'
 end

--- a/app/controllers/concerns/open_une_connector.rb
+++ b/app/controllers/concerns/open_une_connector.rb
@@ -2,8 +2,8 @@
 # frozen_string_literal: true
 
 class OpenUNEConnector < AbstractXikoloConnector
-  NAME = 'openUNE'.freeze
-  ROOT_API = 'https://openune.cn/api/'.freeze
-  ROOT_API_V2 = 'https://openune.cn/api/v2/'.freeze
-  COURSE_LINK = 'https://openune.cn/courses/'.freeze
+  NAME = 'openUNE'
+  ROOT_API = 'https://openune.cn/api/'
+  ROOT_API_V2 = 'https://openune.cn/api/v2/'
+  COURSE_LINK = 'https://openune.cn/courses/'
 end

--- a/app/workers/abstract_xikolo_course_worker.rb
+++ b/app/workers/abstract_xikolo_course_worker.rb
@@ -2,9 +2,9 @@
 # frozen_string_literal: true
 
 class AbstractXikoloCourseWorker < AbstractCourseWorker
-  MOOC_PROVIDER_NAME = ''.freeze
-  MOOC_PROVIDER_API_LINK = ''.freeze
-  COURSE_LINK_BODY = ''.freeze
+  MOOC_PROVIDER_NAME = ''
+  MOOC_PROVIDER_API_LINK = ''
+  COURSE_LINK_BODY = ''
 
   def mooc_provider
     MoocProvider.find_by_name(self.class::MOOC_PROVIDER_NAME)

--- a/app/workers/cnmooc_house_course_worker.rb
+++ b/app/workers/cnmooc_house_course_worker.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 class CnmoocHouseCourseWorker < AbstractXikoloCourseWorker
-  MOOC_PROVIDER_NAME = 'cnmooc.house'.freeze
-  MOOC_PROVIDER_API_LINK = 'https://cnmooc.house/api/courses'.freeze
-  COURSE_LINK_BODY = 'https://cnmooc.house/courses/'.freeze
+  MOOC_PROVIDER_NAME = 'cnmooc.house'
+  MOOC_PROVIDER_API_LINK = 'https://cnmooc.house/api/courses'
+  COURSE_LINK_BODY = 'https://cnmooc.house/courses/'
 end

--- a/app/workers/coursera_course_worker.rb
+++ b/app/workers/coursera_course_worker.rb
@@ -2,15 +2,15 @@
 # frozen_string_literal: true
 
 class CourseraCourseWorker < AbstractCourseWorker
-  MOOC_PROVIDER_NAME = 'coursera'.freeze
-  MOOC_PROVIDER_COURSE_API_LINK = 'https://api.coursera.org/api/catalog.v1/courses'.freeze
-  MOOC_PROVIDER_COURSE_FIELDS = '?fields=language,subtitleLanguagesCsv,shortDescription,photo,aboutTheCourse,video,targetAudience,instructor,estimatedClassWorkload,recommendedBackground'.freeze
-  MOOC_PROVIDER_SESSIONS_API_LINK = 'https://api.coursera.org/api/catalog.v1/sessions'.freeze
-  MOOC_PROVIDER_SESSIONS_FIELDS = '?fields=courseId,startDay,startMonth,startYear,durationString,active,eligibleForCertificates,eligibleForSignatureTrack,signatureTrackPrice,signatureTrackRegularPrice'.freeze
-  COURSE_LINK_BODY = 'https://www.coursera.org/course/'.freeze
-  TARGET_AUDIENCE_0 = 'Basic Undergraduates'.freeze
-  TARGET_AUDIENCE_1 = 'Advanced undergraduates or beginning graduates'.freeze
-  TARGET_AUDIENCE_2 = 'Advanced graduates'.freeze
+  MOOC_PROVIDER_NAME = 'coursera'
+  MOOC_PROVIDER_COURSE_API_LINK = 'https://api.coursera.org/api/catalog.v1/courses'
+  MOOC_PROVIDER_COURSE_FIELDS = '?fields=language,subtitleLanguagesCsv,shortDescription,photo,aboutTheCourse,video,targetAudience,instructor,estimatedClassWorkload,recommendedBackground'
+  MOOC_PROVIDER_SESSIONS_API_LINK = 'https://api.coursera.org/api/catalog.v1/sessions'
+  MOOC_PROVIDER_SESSIONS_FIELDS = '?fields=courseId,startDay,startMonth,startYear,durationString,active,eligibleForCertificates,eligibleForSignatureTrack,signatureTrackPrice,signatureTrackRegularPrice'
+  COURSE_LINK_BODY = 'https://www.coursera.org/course/'
+  TARGET_AUDIENCE_0 = 'Basic Undergraduates'
+  TARGET_AUDIENCE_1 = 'Advanced undergraduates or beginning graduates'
+  TARGET_AUDIENCE_2 = 'Advanced graduates'
 
   def mooc_provider
     MoocProvider.find_by_name(MOOC_PROVIDER_NAME)
@@ -78,7 +78,7 @@ class CourseraCourseWorker < AbstractCourseWorker
         course.start_date = Time.zone.local(session_element['startYear'], session_element['startMonth'], session_element['startDay'])
       end
 
-      course.requirements = if corresponding_course['recommendedBackground'].length > 0
+      course.requirements = if corresponding_course['recommendedBackground'].present?
                               [corresponding_course['recommendedBackground']]
                             end
 

--- a/app/workers/edx_course_worker.rb
+++ b/app/workers/edx_course_worker.rb
@@ -4,8 +4,8 @@ require 'nokogiri'
 require 'open-uri'
 
 class EdxCourseWorker < AbstractCourseWorker
-  MOOC_PROVIDER_NAME = 'edX'.freeze
-  MOOC_PROVIDER_API_LINK = 'https://www.edx.org/api/v2/report/course-feed/rss'.freeze
+  MOOC_PROVIDER_NAME = 'edX'
+  MOOC_PROVIDER_API_LINK = 'https://www.edx.org/api/v2/report/course-feed/rss'
 
   def mooc_provider
     MoocProvider.find_by_name(self.class::MOOC_PROVIDER_NAME)

--- a/app/workers/iversity_course_worker.rb
+++ b/app/workers/iversity_course_worker.rb
@@ -5,8 +5,8 @@ class IversityCourseWorker < AbstractCourseWorker
   include Sidekiq::Worker
   require 'rest_client'
 
-  MOOC_PROVIDER_NAME = 'iversity'.freeze
-  MOOC_PROVIDER_API_LINK = 'https://iversity.org/api/v1/courses'.freeze
+  MOOC_PROVIDER_NAME = 'iversity'
+  MOOC_PROVIDER_API_LINK = 'https://iversity.org/api/v1/courses'
 
   def mooc_provider
     MoocProvider.find_by_name(MOOC_PROVIDER_NAME)

--- a/app/workers/mooc_house_course_worker.rb
+++ b/app/workers/mooc_house_course_worker.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 class MoocHouseCourseWorker < AbstractXikoloCourseWorker
-  MOOC_PROVIDER_NAME = 'mooc.house'.freeze
-  MOOC_PROVIDER_API_LINK = 'https://mooc.house/api/courses'.freeze
-  COURSE_LINK_BODY = 'https://mooc.house/courses/'.freeze
+  MOOC_PROVIDER_NAME = 'mooc.house'
+  MOOC_PROVIDER_API_LINK = 'https://mooc.house/api/courses'
+  COURSE_LINK_BODY = 'https://mooc.house/courses/'
 end

--- a/app/workers/open_hpi_china_course_worker.rb
+++ b/app/workers/open_hpi_china_course_worker.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 class OpenHPIChinaCourseWorker < AbstractXikoloCourseWorker
-  MOOC_PROVIDER_NAME = 'openHPI China'.freeze
-  MOOC_PROVIDER_API_LINK = 'https://openhpi.cn/api/courses'.freeze
-  COURSE_LINK_BODY = 'https://openhpi.cn/courses/'.freeze
+  MOOC_PROVIDER_NAME = 'openHPI China'
+  MOOC_PROVIDER_API_LINK = 'https://openhpi.cn/api/courses'
+  COURSE_LINK_BODY = 'https://openhpi.cn/courses/'
 end

--- a/app/workers/open_hpi_course_worker.rb
+++ b/app/workers/open_hpi_course_worker.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 class OpenHPICourseWorker < AbstractXikoloCourseWorker
-  MOOC_PROVIDER_NAME = 'openHPI'.freeze
-  MOOC_PROVIDER_API_LINK = 'https://open.hpi.de/api/courses'.freeze
-  COURSE_LINK_BODY = 'https://open.hpi.de/courses/'.freeze
+  MOOC_PROVIDER_NAME = 'openHPI'
+  MOOC_PROVIDER_API_LINK = 'https://open.hpi.de/api/courses'
+  COURSE_LINK_BODY = 'https://open.hpi.de/courses/'
 end

--- a/app/workers/open_sap_china_course_worker.rb
+++ b/app/workers/open_sap_china_course_worker.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 class OpenSAPChinaCourseWorker < AbstractXikoloCourseWorker
-  MOOC_PROVIDER_NAME = 'openSAP China'.freeze
-  MOOC_PROVIDER_API_LINK = 'https://open.sap.cn/api/courses'.freeze
-  COURSE_LINK_BODY = 'https://open.sap.cn/courses/'.freeze
+  MOOC_PROVIDER_NAME = 'openSAP China'
+  MOOC_PROVIDER_API_LINK = 'https://open.sap.cn/api/courses'
+  COURSE_LINK_BODY = 'https://open.sap.cn/courses/'
 end

--- a/app/workers/open_sap_course_worker.rb
+++ b/app/workers/open_sap_course_worker.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 class OpenSAPCourseWorker < AbstractXikoloCourseWorker
-  MOOC_PROVIDER_NAME = 'openSAP'.freeze
-  MOOC_PROVIDER_API_LINK = 'https://open.sap.com/api/courses'.freeze
-  COURSE_LINK_BODY = 'https://open.sap.com/courses/'.freeze
+  MOOC_PROVIDER_NAME = 'openSAP'
+  MOOC_PROVIDER_API_LINK = 'https://open.sap.com/api/courses'
+  COURSE_LINK_BODY = 'https://open.sap.com/courses/'
 end

--- a/app/workers/open_une_course_worker.rb
+++ b/app/workers/open_une_course_worker.rb
@@ -2,7 +2,7 @@
 # frozen_string_literal: true
 
 class OpenUNECourseWorker < AbstractXikoloCourseWorker
-  MOOC_PROVIDER_NAME = 'openUNE'.freeze
-  MOOC_PROVIDER_API_LINK = 'https://openune.cn/api/courses'.freeze
-  COURSE_LINK_BODY = 'https://openune.cn/courses/'.freeze
+  MOOC_PROVIDER_NAME = 'openUNE'
+  MOOC_PROVIDER_API_LINK = 'https://openune.cn/api/courses'
+  COURSE_LINK_BODY = 'https://openune.cn/courses/'
 end

--- a/app/workers/udacity_course_worker.rb
+++ b/app/workers/udacity_course_worker.rb
@@ -5,8 +5,8 @@ class UdacityCourseWorker < AbstractCourseWorker
   include Sidekiq::Worker
   require 'rest_client'
 
-  MOOC_PROVIDER_NAME = 'Udacity'.freeze
-  MOOC_PROVIDER_API_LINK = 'https://www.udacity.com/public-api/v0/courses'.freeze
+  MOOC_PROVIDER_NAME = 'Udacity'
+  MOOC_PROVIDER_API_LINK = 'https://www.udacity.com/public-api/v0/courses'
 
   def mooc_provider
     MoocProvider.find_by_name(MOOC_PROVIDER_NAME)

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -308,7 +308,7 @@ RSpec.describe GroupsController, type: :controller do
     it 'destroys the membership of all users of the deleted group and only of the deleted group' do
       user_1 = FactoryGirl.create(:user)
       user_2 = FactoryGirl.create(:user)
-      group_with_admin.update(users: [user, user_1, user_2])
+      group_with_admin[:users] = [user, user_1, user_2]
       group_2 = FactoryGirl.create(:group, users: [user, user_1, user_2])
       expect do
         delete :destroy, id: group_with_admin.to_param

--- a/spec/controllers/groups_controller_spec.rb
+++ b/spec/controllers/groups_controller_spec.rb
@@ -308,7 +308,7 @@ RSpec.describe GroupsController, type: :controller do
     it 'destroys the membership of all users of the deleted group and only of the deleted group' do
       user_1 = FactoryGirl.create(:user)
       user_2 = FactoryGirl.create(:user)
-      group_with_admin[:users] = [user, user_1, user_2]
+      group_with_admin.users = [user, user_1, user_2]
       group_2 = FactoryGirl.create(:group, users: [user, user_1, user_2])
       expect do
         delete :destroy, id: group_with_admin.to_param


### PR DESCRIPTION
Rubocop just got updated and somehow reverts some changes introduced with the previous update, mainly because we enabled the frozen string literal everywhere.