### PR TITLE
Setting null values of timestamps for Activities explicit

### DIFF
--- a/db/migrate/20150610122906_create_activities.rb
+++ b/db/migrate/20150610122906_create_activities.rb
@@ -12,7 +12,7 @@ class CreateActivities < ActiveRecord::Migration
       t.text :parameters
       t.belongs_to :recipient, type: 'uuid', polymorphic: true
 
-      t.timestamps
+      t.timestamps null: false
     end
 
     add_index :activities, [:trackable_id, :trackable_type]

--- a/db/migrate/20160206035823_disallow_null_values_for_timestamps_in_activities.rb
+++ b/db/migrate/20160206035823_disallow_null_values_for_timestamps_in_activities.rb
@@ -1,3 +1,6 @@
+# encoding: utf-8
+# frozen_string_literal: true
+
 class DisallowNullValuesForTimestampsInActivities < ActiveRecord::Migration
   def change
     change_column_null :activities, :created_at, false

--- a/db/migrate/20160206035823_disallow_null_values_for_timestamps_in_activities.rb
+++ b/db/migrate/20160206035823_disallow_null_values_for_timestamps_in_activities.rb
@@ -1,0 +1,6 @@
+class DisallowNullValuesForTimestampsInActivities < ActiveRecord::Migration
+  def change
+    change_column_null :activities, :created_at, false
+    change_column_null :activities, :updated_at, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160131153052) do
+ActiveRecord::Schema.define(version: 20160206035823) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -26,10 +26,10 @@ ActiveRecord::Schema.define(version: 20160131153052) do
     t.text     "parameters"
     t.uuid     "recipient_id"
     t.string   "recipient_type"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.uuid     "user_ids",       array: true
-    t.uuid     "group_ids",      array: true
+    t.datetime "created_at",     null: false
+    t.datetime "updated_at",     null: false
+    t.uuid     "user_ids",                    array: true
+    t.uuid     "group_ids",                   array: true
   end
 
   add_index "activities", ["owner_id", "owner_type"], name: "index_activities_on_owner_id_and_owner_type", using: :btree


### PR DESCRIPTION
Unfortunately, we had a deprecation warning in one of our migrations. Of course, I know that changing a migration is not recommended. Nevertheless, if we wouldn't change this, the behaviour of this migration might be different in Rails 5 than it is now. Therefore, I decided to touch the migration and in addition to write a new one in order to ensure that all instances of mammon run with the same schema.