### PR TITLE
Improve Error handling for API connections

### DIFF
--- a/app/workers/abstract_course_worker.rb
+++ b/app/workers/abstract_course_worker.rb
@@ -11,7 +11,7 @@ class AbstractCourseWorker
 
   def load_courses
     response_data = course_data
-  rescue SocketError, RestClient::ResourceNotFound, RestClient::SSLCertificateNotVerified => e
+  rescue SocketError, Errno::ECONNREFUSED, RestClient::ResourceNotFound, RestClient::SSLCertificateNotVerified => e
     Rails.logger.error "#{e.class}: #{e.message}"
   else
     handle_response_data response_data


### PR DESCRIPTION
We had an issue with our workers and connectors whenever the external API was not available and the connection got reset by the host. This PR is going to fix that problem and to catch it properly.