### PR TITLE
Add format.js in current_user_with_evaluation to prevent an exception

### DIFF
--- a/app/controllers/apis_controller.rb
+++ b/app/controllers/apis_controller.rb
@@ -40,6 +40,9 @@ class ApisController < ApplicationController
   rescue ActionController::ParameterMissing, ActiveRecord::RecordNotFound => e
     respond_to do |format|
       format.json { render json: {error: e.message}, status: :recordNotFound }
+      format.js do
+        render json: {error: e.message}, callback: params[:callback], status: :recordNotFound
+      end
     end
   end
 end

--- a/spec/models/user_email_spec.rb
+++ b/spec/models/user_email_spec.rb
@@ -67,7 +67,6 @@ RSpec.describe UserEmail, type: :model do
     end
 
     it 'is not allowed to destroy the primary address' do
-      pending 'spec fails randomly on CircleCI.'
       email = FactoryGirl.create(:user_email, user: user, is_primary: true)
       expect { email.destroy! }.to raise_error ActiveRecord::RecordNotDestroyed
       expect(described_class.where(user: user, is_primary: true).count).to eq 1


### PR DESCRIPTION
We got an exception when loading the widget on one of our staging or developer platforms while being signed in at mammooc. This change is going to prevent the exception and returns a corresponding result.

Exception: ActionController::UnknownFormat
Details: https://rpm.newrelic.com/accounts/973231/applications/6907121/traced_errors/88a7233b-4ac5-11e6-ac40-f8bc12425d4c_0_15717