### PR TITLE
Change name of MOOC providers in workers to match the names in our seeds

### DIFF
--- a/app/controllers/concerns/connector_mapper.rb
+++ b/app/controllers/concerns/connector_mapper.rb
@@ -9,15 +9,15 @@ module ConnectorMapper
         return OpenHPIConnector.new
       when 'openSAP'
         return OpenSAPConnector.new
-      when 'openHPI China'
+      when 'openHPI.cn'
         return OpenHPIChinaConnector.new
-      when 'openSAP China'
+      when 'openSAP.cn'
         return OpenSAPChinaConnector.new
       when 'mooc.house'
         return MoocHouseConnector.new
-      when 'cnmooc.house'
+      when 'cnMOOC.house'
         return CnmoocHouseConnector.new
-      when 'openUNE'
+      when 'openUNE.cn'
         return OpenUNEConnector.new
       when 'coursera'
         return CourseraConnector.new
@@ -32,15 +32,15 @@ module ConnectorMapper
         return OpenHPIUserWorker
       when 'openSAP'
         return OpenSAPUserWorker
-      when 'openHPI China'
+      when 'openHPI.cn'
         return OpenHPIChinaUserWorker
-      when 'openSAP China'
+      when 'openSAP.cn'
         return OpenSAPChinaUserWorker
       when 'mooc.house'
         return MoocHouseUserWorker
-      when 'cnmooc.house'
+      when 'cnMOOC.house'
         return CnmoocHouseUserWorker
-      when 'openUNE'
+      when 'openUNE.cn'
         return OpenUNEUserWorker
       when 'coursera'
         return CourseraUserWorker

--- a/app/workers/cnmooc_house_course_worker.rb
+++ b/app/workers/cnmooc_house_course_worker.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class CnmoocHouseCourseWorker < AbstractXikoloCourseWorker
-  MOOC_PROVIDER_NAME = 'cnmooc.house'
+  MOOC_PROVIDER_NAME = 'cnMOOC.house'
   MOOC_PROVIDER_API_LINK = 'https://cnmooc.house/api/courses'
   COURSE_LINK_BODY = 'https://cnmooc.house/courses/'
 end

--- a/app/workers/open_hpi_china_course_worker.rb
+++ b/app/workers/open_hpi_china_course_worker.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class OpenHPIChinaCourseWorker < AbstractXikoloCourseWorker
-  MOOC_PROVIDER_NAME = 'openHPI China'
+  MOOC_PROVIDER_NAME = 'openHPI.cn'
   MOOC_PROVIDER_API_LINK = 'https://openhpi.cn/api/courses'
   COURSE_LINK_BODY = 'https://openhpi.cn/courses/'
 end

--- a/app/workers/open_sap_china_course_worker.rb
+++ b/app/workers/open_sap_china_course_worker.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class OpenSAPChinaCourseWorker < AbstractXikoloCourseWorker
-  MOOC_PROVIDER_NAME = 'openSAP China'
+  MOOC_PROVIDER_NAME = 'openSAP.cn'
   MOOC_PROVIDER_API_LINK = 'https://open.sap.cn/api/courses'
   COURSE_LINK_BODY = 'https://open.sap.cn/courses/'
 end

--- a/app/workers/open_une_course_worker.rb
+++ b/app/workers/open_une_course_worker.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class OpenUNECourseWorker < AbstractXikoloCourseWorker
-  MOOC_PROVIDER_NAME = 'openUNE'
+  MOOC_PROVIDER_NAME = 'openUNE.cn'
   MOOC_PROVIDER_API_LINK = 'https://openune.cn/api/courses'
   COURSE_LINK_BODY = 'https://openune.cn/courses/'
 end

--- a/spec/controllers/concerns/connector_mapper_spec.rb
+++ b/spec/controllers/concerns/connector_mapper_spec.rb
@@ -14,15 +14,15 @@ RSpec.describe ConnectorMapper do
     expect(get_connector_by_mooc_provider(mooc_provider).class).to eq OpenHPIConnector
     mooc_provider.name = 'openSAP'
     expect(get_connector_by_mooc_provider(mooc_provider).class).to eq OpenSAPConnector
-    mooc_provider.name = 'openHPI China'
+    mooc_provider.name = 'openHPI.cn'
     expect(get_connector_by_mooc_provider(mooc_provider).class).to eq OpenHPIChinaConnector
-    mooc_provider.name = 'openSAP China'
+    mooc_provider.name = 'openSAP.cn'
     expect(get_connector_by_mooc_provider(mooc_provider).class).to eq OpenSAPChinaConnector
     mooc_provider.name = 'mooc.house'
     expect(get_connector_by_mooc_provider(mooc_provider).class).to eq MoocHouseConnector
-    mooc_provider.name = 'cnmooc.house'
+    mooc_provider.name = 'cnMOOC.house'
     expect(get_connector_by_mooc_provider(mooc_provider).class).to eq CnmoocHouseConnector
-    mooc_provider.name = 'openUNE'
+    mooc_provider.name = 'openUNE.cn'
     expect(get_connector_by_mooc_provider(mooc_provider).class).to eq OpenUNEConnector
     mooc_provider.name = 'coursera'
     expect(get_connector_by_mooc_provider(mooc_provider).class).to eq CourseraConnector
@@ -37,15 +37,15 @@ RSpec.describe ConnectorMapper do
     expect(get_worker_by_mooc_provider(mooc_provider)).to eq OpenHPIUserWorker
     mooc_provider.name = 'openSAP'
     expect(get_worker_by_mooc_provider(mooc_provider)).to eq OpenSAPUserWorker
-    mooc_provider.name = 'openHPI China'
+    mooc_provider.name = 'openHPI.cn'
     expect(get_worker_by_mooc_provider(mooc_provider)).to eq OpenHPIChinaUserWorker
-    mooc_provider.name = 'openSAP China'
+    mooc_provider.name = 'openSAP.cn'
     expect(get_worker_by_mooc_provider(mooc_provider)).to eq OpenSAPChinaUserWorker
     mooc_provider.name = 'mooc.house'
     expect(get_worker_by_mooc_provider(mooc_provider)).to eq MoocHouseUserWorker
-    mooc_provider.name = 'cnmooc.house'
+    mooc_provider.name = 'cnMOOC.house'
     expect(get_worker_by_mooc_provider(mooc_provider)).to eq CnmoocHouseUserWorker
-    mooc_provider.name = 'openUNE'
+    mooc_provider.name = 'openUNE.cn'
     expect(get_worker_by_mooc_provider(mooc_provider)).to eq OpenUNEUserWorker
     mooc_provider.name = 'coursera'
     expect(get_worker_by_mooc_provider(mooc_provider)).to eq CourseraUserWorker

--- a/spec/models/user_email_spec.rb
+++ b/spec/models/user_email_spec.rb
@@ -67,7 +67,6 @@ RSpec.describe UserEmail, type: :model do
     end
 
     it 'is not allowed to destroy the primary address' do
-      pending 'spec fails randomly on CircleCI.'
       email = FactoryGirl.create(:user_email, user: user, is_primary: true)
       expect { email.destroy! }.to raise_error ActiveRecord::RecordNotDestroyed
       expect(described_class.where(user: user, is_primary: true).count).to eq 1

--- a/spec/workers/cnmooc_house_course_worker_spec.rb
+++ b/spec/workers/cnmooc_house_course_worker_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe CnmoocHouseCourseWorker do
-  let!(:mooc_provider) { FactoryGirl.create(:mooc_provider, name: 'cnmooc.house') }
+  let!(:mooc_provider) { FactoryGirl.create(:mooc_provider, name: 'cnMOOC.house') }
 
   let(:cnmooc_house_course_worker) { described_class.new }
 

--- a/spec/workers/open_hpi_china_course_worker_spec.rb
+++ b/spec/workers/open_hpi_china_course_worker_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe OpenHPIChinaCourseWorker do
-  let!(:mooc_provider) { FactoryGirl.create(:mooc_provider, name: 'openHPI China') }
+  let!(:mooc_provider) { FactoryGirl.create(:mooc_provider, name: 'openHPI.cn') }
 
   let(:open_hpi_china_course_worker) { described_class.new }
 

--- a/spec/workers/open_sap_china_course_worker_spec.rb
+++ b/spec/workers/open_sap_china_course_worker_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe OpenSAPChinaCourseWorker do
-  let!(:mooc_provider) { FactoryGirl.create(:mooc_provider, name: 'openSAP China') }
+  let!(:mooc_provider) { FactoryGirl.create(:mooc_provider, name: 'openSAP.cn') }
 
   let(:open_sap_china_course_worker) { described_class.new }
 

--- a/spec/workers/open_une_course_worker_spec.rb
+++ b/spec/workers/open_une_course_worker_spec.rb
@@ -2,7 +2,7 @@
 require 'rails_helper'
 
 RSpec.describe OpenUNECourseWorker do
-  let!(:mooc_provider) { FactoryGirl.create(:mooc_provider, name: 'openUNE') }
+  let!(:mooc_provider) { FactoryGirl.create(:mooc_provider, name: 'openUNE.cn') }
 
   let(:open_une_course_worker) { described_class.new }
 


### PR DESCRIPTION
We changed some names of our MOOC providers with #695 but forgot to change the names in our workers as well. This PR should add the missing changes.