### PR TITLE
Use localized language name in emails

### DIFF
--- a/app/views/user_mailer/newsletter_for_new_courses.html.slim
+++ b/app/views/user_mailer/newsletter_for_new_courses.html.slim
@@ -58,10 +58,12 @@ html
                       = image_tag('/data/icons/globe.png', style: 'height: 18px; padding-right: 5px; vertical-align: middle;')
                       - language_array = course.language.split(',')
                       - language_array.each do |language|
-                        - if I18n.t("language.#{language}").include? 'translation missing'
+                        - if I18n.t("language.#{language}", locale: :de).include? 'translation missing'
                           = language
+                          - unless language_array.last == language
+                            = ', '
                         - else
-                          = I18n.t("language.#{language}")
+                          = I18n.t("language.#{language}", locale: :de)
                           - unless language_array.last == language
                             = ', '
                   div style="position: absolute; bottom: 10px; right: 10px;"
@@ -120,10 +122,12 @@ html
                       =image_tag('/data/icons/globe.png', style: 'height: 18px; padding-right: 5px; vertical-align: middle;')
                       - language_array = course.language.split(',')
                       - language_array.each do |language|
-                        - if I18n.t("language.#{language}").include? 'translation missing'
+                        - if I18n.t("language.#{language}", locale: :en).include? 'translation missing'
                           = language
+                          - unless language_array.last == language
+                            = ', '
                         - else
-                          = I18n.t("language.#{language}")
+                          = I18n.t("language.#{language}", locale: :en)
                           - unless language_array.last == language
                             = ', '
                   div style="position: absolute; bottom: 10px; right: 10px;"

--- a/spec/models/user_email_spec.rb
+++ b/spec/models/user_email_spec.rb
@@ -67,7 +67,6 @@ RSpec.describe UserEmail, type: :model do
     end
 
     it 'is not allowed to destroy the primary address' do
-      pending 'spec fails randomly on CircleCI.'
       email = FactoryGirl.create(:user_email, user: user, is_primary: true)
       expect { email.destroy! }.to raise_error ActiveRecord::RecordNotDestroyed
       expect(described_class.where(user: user, is_primary: true).count).to eq 1


### PR DESCRIPTION
In addition, this PR adds a comma if no translation could be found but the course is offered in at least one other language.