### PR TITLE
Fix JSON API worker

### DIFF
--- a/app/workers/mooin_course_worker.rb
+++ b/app/workers/mooin_course_worker.rb
@@ -3,4 +3,5 @@
 class MooinCourseWorker < AbstractJsonApiCourseWorker
   MOOC_PROVIDER_NAME = 'mooin'
   MOOC_PROVIDER_API_LINK = 'https://moodalis.oncampus.de/files/moochub.php'
+  COURSE_LINK_BODY = 'https://mooin.oncampus.de/local/ildcourseinfo/index.php?id='
 end

--- a/spec/workers/mooin_course_worker_spec.rb
+++ b/spec/workers/mooin_course_worker_spec.rb
@@ -162,7 +162,7 @@ RSpec.describe MooinCourseWorker do
     expect(course.name).to eq json_course['name'].strip
     expect(course.provider_course_id).to eq json_course['courseCode']
     expect(course.mooc_provider_id).to eq mooc_provider.id
-    expect(course.url).to eq json_course['moocProvider']['url']
+    expect(course.url).to eq described_class::COURSE_LINK_BODY + json_course['courseCode']
     expect(course.videoId).to be_nil
     expect(course.language).to eq json_course['languages'].join(',')
     expect(course.start_date).to eq Time.zone.parse(json_course['startDate'])


### PR DESCRIPTION
- Fixes a crash when parsing illegal durations

- Changes the URL to courses based on the course code on mooin if no separate URL was provided in the JSON