### PR TITLE
Don't pin ruby version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ jobs:
     parallelism: 4
     working_directory: ~/mammooc.org
     docker:
-      - image: circleci/ruby:2.5.1-node-browsers
+      - image: circleci/ruby:2.5-node-browsers
         environment:
           RAILS_ENV: test
           COVERALLS_PARALLEL: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.5.1
+FROM ruby:2.5
 
 RUN apt-get update -qq && apt-get install -y build-essential
 

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-ruby '2.5.1'
+ruby '~> 2.5'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '5.2.2.1'


### PR DESCRIPTION
ruby has a version 2.5.5p157 on Ubuntu bionic. Installing rails with a pinned version (2.5.1) fails.